### PR TITLE
Only publish on push

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      is_push: ${{ github.event_name == 'push' }}
+
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
@@ -24,6 +27,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Publish VacheTache
+      if: ${{ env.PUSH_PACKAGES }}
       uses: brandedoutcast/publish-nuget@v2
       with:
           PROJECT_FILE_PATH: VacheTacheLibrary/VacheTacheLibrary.csproj

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VacheTache
 
-Version 1.1.0  
+Version 1.1.3  
 
 ## VacheTache class
 


### PR DESCRIPTION
This commit fixes the issue that the ci/cd tries to publish a package
whenever a PR is for master. Now only pushes to master should publish.